### PR TITLE
Housing gdp

### DIFF
--- a/ASX_Housing_GDP_README.md
+++ b/ASX_Housing_GDP_README.md
@@ -1,4 +1,4 @@
-### Housing vs Per Capita GDP vs ASX 200 Index v3
+### Housing vs Per Capita GDP vs ASX 200 Index v4
 
 #### datasets used:
 `asx200_month`
@@ -6,13 +6,10 @@
 `new_loan_commitment_value_properties_purchased`
 
 #### Visualisations:
-Housing Commitment vs Per Capita GDP (2002-07-01 ~ 2019-01-01)
-Housing Commitment vs ASX 200 Index (2002-07-01 ~ 2020-07-01)
-ASX 200 Index vs Per Capita GDP (1993-01-01 ~ 2019-01-01)
-Housing Commitment vs ASX 200 Index vs Per Capita GDP (2002-07-01 ~ 2019-01-01)
+Housing Commitment vs Per Capita GDP
+Housing Commitment vs ASX 200 Index 
+ASX 200 Index vs Per Capita GDP
 
-Optional (to do):
-Annual growth of ASX 200 Index and Housing Commitment
-Annual growth of ASX 200 Index and Per Capita GDP
-
-
+ASX 200 Index and Annual growth of ASX 200 Index
+Per Capita GDP and Annual growth of Per Capita GDP
+Housing Commitment and Annaul growth of Housing Commitment

--- a/ASX_Housing_GDP_README.md
+++ b/ASX_Housing_GDP_README.md
@@ -9,7 +9,10 @@
 Housing Commitment vs Per Capita GDP
 Housing Commitment vs ASX 200 Index 
 ASX 200 Index vs Per Capita GDP
+Correlation Coefficient and linear plots
 
+The following plots could be removed from the final report
+Distribution plots
 ASX 200 Index and Annual growth of ASX 200 Index
 Per Capita GDP and Annual growth of Per Capita GDP
 Housing Commitment and Annaul growth of Housing Commitment


### PR DESCRIPTION
### Restructured codes in `Housing_GDP.ipynb` for better visualisations for ASX 200 Index & Per Capita GDP & Housing Commitment (in 3 pairs)
--------------
# The issue

What was the issue?
1. Restructured EDA section for better display of distributions plots. Not sure if they should be included in the markdown file (and the "final report"). The plots look good themselves. However, due to the limits words/space in the "final report", I dont think these plots are actually related to the topic. On the other hands, they could be part of the EDA.  Any thought? 

2. Added Correlation Coefficients and explanations for the three main comparison plots. There are three individual plots to show history values and changes of ASX 200 Index & Per Capita GDP & Housing Commitment. However, not sure if they should be included in the markdown file (and the "final report") as well. Depends on how many visualisations other ASX comparison topics have. 

# The solution
Leave them there for now. They can be easily removed later when building the "final report" if necessary.

This is the final version of code. But the explanations and markdown parts are still draft. Will finish polishing them as soon as I can (Hopefully by Monday).

What did you do to fix it?
n/a

# Visuals

Before | After
----- | -----
A | B

# Test cases

How can we thoroughly test this? Include sign-in information, if needed.
